### PR TITLE
issue#130: redirect to artist on click

### DIFF
--- a/Electron/src/__tests__/components/ContextMenu/ContextMenuSong.test.tsx
+++ b/Electron/src/__tests__/components/ContextMenu/ContextMenuSong.test.tsx
@@ -5,9 +5,12 @@ import ContextMenuSong from 'components/AdvancedUIComponents/ContextMenu/Song/Co
 import Global from 'global/global';
 import { UserType } from 'utils/role';
 import Token from 'utils/token';
+import * as router from 'react-router';
+import { BrowserRouter } from 'react-router-dom';
 
 const playlistName = 'playlisttest';
 const songName = 'songName';
+const artistName = 'artistName';
 const userName = 'prueba';
 const roleUser = UserType.ARTIST;
 
@@ -40,6 +43,9 @@ const playlistDTOMockFetch = {
   number_of_plays: 2,
 }; */
 
+const navigate = jest.fn();
+
+jest.spyOn(router, 'useNavigate').mockImplementation(() => navigate);
 jest.spyOn(Token, 'getTokenUsername').mockReturnValue(userName);
 jest.spyOn(Token, 'getTokenRole').mockReturnValue(roleUser);
 
@@ -107,13 +113,16 @@ global.fetch = jest.fn((url: string, options: any) => {
 test('Render ContextMenuSong', async () => {
   const component = await act(() => {
     return render(
-      <ContextMenuSong
-        playlistName={playlistName}
-        songName={songName}
-        handleCloseParent={jest.fn()}
-        refreshPlaylistData={jest.fn()}
-        refreshSidebarData={jest.fn()}
-      />,
+      <BrowserRouter>
+        <ContextMenuSong
+          playlistName={playlistName}
+          songName={songName}
+          artistName={artistName}
+          handleCloseParent={jest.fn()}
+          refreshPlaylistData={jest.fn()}
+          refreshSidebarData={jest.fn()}
+        />
+      </BrowserRouter>,
     );
   });
   expect(component).toBeTruthy();
@@ -124,13 +133,16 @@ test('ContextMenuSong quitar de esta lista', async () => {
 
   const component = await act(() => {
     return render(
-      <ContextMenuSong
-        playlistName={playlistName}
-        songName={songName}
-        handleCloseParent={jest.fn()}
-        refreshPlaylistData={refreshPlaylistDataMock}
-        refreshSidebarData={jest.fn()}
-      />,
+      <BrowserRouter>
+        <ContextMenuSong
+          playlistName={playlistName}
+          songName={songName}
+          artistName={artistName}
+          handleCloseParent={jest.fn()}
+          refreshPlaylistData={refreshPlaylistDataMock}
+          refreshSidebarData={jest.fn()}
+        />
+      </BrowserRouter>,
     );
   });
 
@@ -154,13 +166,16 @@ test('ContextMenuSong crear lista', async () => {
 
   const component = await act(() => {
     return render(
-      <ContextMenuSong
-        playlistName={playlistName}
-        songName={songName}
-        handleCloseParent={jest.fn()}
-        refreshPlaylistData={jest.fn()}
-        refreshSidebarData={refreshSidebarMock}
-      />,
+      <BrowserRouter>
+        <ContextMenuSong
+          playlistName={playlistName}
+          songName={songName}
+          artistName={artistName}
+          handleCloseParent={jest.fn()}
+          refreshPlaylistData={jest.fn()}
+          refreshSidebarData={refreshSidebarMock}
+        />
+      </BrowserRouter>,
     );
   });
 
@@ -191,13 +206,16 @@ test('ContextMenuSong crear lista', async () => {
 test('ContextMenuSong add to playlist', async () => {
   const component = await act(() => {
     return render(
-      <ContextMenuSong
-        playlistName={playlistName}
-        songName={songName}
-        handleCloseParent={jest.fn()}
-        refreshPlaylistData={jest.fn()}
-        refreshSidebarData={jest.fn()}
-      />,
+      <BrowserRouter>
+        <ContextMenuSong
+          playlistName={playlistName}
+          songName={songName}
+          artistName={artistName}
+          handleCloseParent={jest.fn()}
+          refreshPlaylistData={jest.fn()}
+          refreshSidebarData={jest.fn()}
+        />
+      </BrowserRouter>,
     );
   });
 

--- a/Electron/src/components/AdvancedUIComponents/ContextMenu/Song/ContextMenuSong.tsx
+++ b/Electron/src/components/AdvancedUIComponents/ContextMenu/Song/ContextMenuSong.tsx
@@ -6,6 +6,7 @@ import { InfoPopoverType } from 'components/AdvancedUIComponents/InfoPopOver/typ
 import Global from 'global/global';
 import Token from 'utils/token';
 import { backendPathFromUserType } from 'utils/role';
+import { useNavigate } from 'react-router-dom';
 import styles from '../contextMenu.module.css';
 import { PropsContextMenuSong } from '../types/PropsContextMenu';
 
@@ -17,11 +18,16 @@ const MessagesInfoPopOver = {
 
 export default function ContextMenuSong({
   songName,
+  artistName,
   playlistName,
   handleCloseParent,
   refreshPlaylistData,
   refreshSidebarData,
 }: PropsContextMenuSong) {
+  const navigate = useNavigate();
+
+  const urlArtist = `/artist/${artistName}`;
+
   const [isOpen, setIsOpen] = useState(false);
 
   const [anchorEl, setAnchorEl] = useState(null);
@@ -34,6 +40,12 @@ export default function ContextMenuSong({
   const handleClose = () => {
     setAnchorEl(null);
     handleCloseParent();
+  };
+
+  const handleClickGoToArtist = (event: any) => {
+    event.preventDefault();
+    event.stopPropagation();
+    navigate(urlArtist);
   };
 
   const open = Boolean(anchorEl);
@@ -212,7 +224,9 @@ export default function ContextMenuSong({
         </li>
         <li>
           <button type="button">Ir a radio de la canción</button>
-          <button type="button">Ir al artista</button>
+          <button type="button" onClick={(e) => handleClickGoToArtist(e)}>
+            Ir al artista
+          </button>
           <button type="button">Ir al álbum</button>
         </li>
         <li>

--- a/Electron/src/components/AdvancedUIComponents/ContextMenu/types/PropsContextMenu.tsx
+++ b/Electron/src/components/AdvancedUIComponents/ContextMenu/types/PropsContextMenu.tsx
@@ -14,4 +14,5 @@ export interface PropsContextMenuPlaylist extends PropsContextMenu {
 export interface PropsContextMenuSong extends PropsContextMenu {
   playlistName: string;
   songName: string;
+  artistName: string;
 }

--- a/Electron/src/components/Cards/SongCard/SongCard.tsx
+++ b/Electron/src/components/Cards/SongCard/SongCard.tsx
@@ -119,6 +119,7 @@ export default function SongCard({
         >
           <ContextMenuSong
             songName={name}
+            artistName={artist}
             playlistName=""
             handleCloseParent={handleClose}
             refreshPlaylistData={() => {}}

--- a/Electron/src/components/Song/Song.tsx
+++ b/Electron/src/components/Song/Song.tsx
@@ -112,6 +112,7 @@ export default function Song({
         >
           <ContextMenuSong
             songName={name}
+            artistName={artistName}
             playlistName={playlistName}
             handleCloseParent={handleClose}
             refreshPlaylistData={refreshPlaylistData}


### PR DESCRIPTION
## Description

When the user clicks on "Ir al artista" in the song menu, it redirects to the artist page.

## Commit type
  - `feat`: indicates the addition of a new feature or functionality to the project.
 
## Issue

Clicking on "Ir al artista" does not redirect to relevant artist page

## Solution

add an on click event to the button to redirect to the artist url

## Proposed Changes

- add new prop called artistName
- add onclick event to the button
- update test file

## Potential Impact

<!-- Describe the impact these changes may have on the project. Include any risks or side effects to consider. -->

## Tests Performed

- [] Test performed <!-- Check if performed  - [✅ | ❎] Test performed -->
## Screenshots

<!-- If applicable, provide screenshots that help visualize the changes made. -->

## Additional Tasks

<!-- List any additional tasks that need to be performed after the pull request is merged, such as documentation updates, additional testing, etc. -->

## Assigned

<!-- Mention the team members assigned to review and merge this pull request. -->

@AntonioMrtz <!-- Default -->
