### PR TITLE
Add logger.warning for default and missing mapped values

### DIFF
--- a/Backend/app/common/PropertiesManager.py
+++ b/Backend/app/common/PropertiesManager.py
@@ -81,8 +81,6 @@ class _PropertiesManager:
         for key, value in self.config.items(config_section):
             if value == "":
                 value = None
-            if value is None:
-                properties_manager_logger.warning(f"Using None for {key} in {config_section}")
             setattr(self, key, value)
 
     def _load_architecture(self):

--- a/Backend/app/common/PropertiesManager.py
+++ b/Backend/app/common/PropertiesManager.py
@@ -79,7 +79,7 @@ class _PropertiesManager:
 
         """
         for key, value in self.config.items(config_section):
-            if value == "":
+            if value == "" or value is None:
                 value = None
                 properties_manager_logger.warning(f"Using None for {key} in {config_section}")
             setattr(self, key, value)

--- a/Backend/app/common/PropertiesManager.py
+++ b/Backend/app/common/PropertiesManager.py
@@ -79,7 +79,7 @@ class _PropertiesManager:
 
         """
         for key, value in self.config.items(config_section):
-            if value == "" or None:
+            if value == "":
                 value = None
                 properties_manager_logger.warning(f"Using None for {key} in {config_section}")
             setattr(self, key, value)

--- a/Backend/app/common/PropertiesManager.py
+++ b/Backend/app/common/PropertiesManager.py
@@ -81,6 +81,8 @@ class _PropertiesManager:
         for key, value in self.config.items(config_section):
             if value == "":
                 value = None
+            if value is None:
+                properties_manager_logger.warning(f"Using None for {key} in {config_section}")
             setattr(self, key, value)
 
     def _load_architecture(self):
@@ -91,7 +93,7 @@ class _PropertiesManager:
         if not architecture_type:
             architecture_type = DEFAULT_ARCHITECTURE
             self.__setattr__(ARCHITECTURE_ENV_NAME, DEFAULT_ARCHITECTURE)
-            properties_manager_logger.info(
+            properties_manager_logger.warning(
                 f"No architecture type selected, using {DEFAULT_ARCHITECTURE}"
             )
         self.__setattr__(ARCHITECTURE_ENV_NAME, architecture_type)

--- a/Backend/app/common/PropertiesManager.py
+++ b/Backend/app/common/PropertiesManager.py
@@ -79,8 +79,9 @@ class _PropertiesManager:
 
         """
         for key, value in self.config.items(config_section):
-            if value == "":
+            if value == "" or None:
                 value = None
+                properties_manager_logger.warning(f"Using None for {key} in {config_section}")
             setattr(self, key, value)
 
     def _load_architecture(self):
@@ -90,7 +91,6 @@ class _PropertiesManager:
         architecture_type = os.getenv(ARCHITECTURE_ENV_NAME, DEFAULT_ARCHITECTURE)
         if not architecture_type:
             architecture_type = DEFAULT_ARCHITECTURE
-            self.__setattr__(ARCHITECTURE_ENV_NAME, DEFAULT_ARCHITECTURE)
             properties_manager_logger.warning(
                 f"No architecture type selected, using {DEFAULT_ARCHITECTURE}"
             )


### PR DESCRIPTION
## Description

added warning log where default value was being used

## Commit type

refactor

## Issue

 Logging warning level if there is no mapping available and the default is being loaded.

## Solution

`logger.warning` is added for default value

## Proposed Changes

-added logger.warning in `PropertiesManager`
-changed info log to warning log 

## Potential Impact

Help in checking for further problems where default value is being loaded.

## Assigned

@AntonioMrtz 
