### PR TITLE
#129: Promote User to Artist

### DIFF
--- a/Backend/app/spotify_electron/user/user/user_repository.py
+++ b/Backend/app/spotify_electron/user/user/user_repository.py
@@ -78,7 +78,36 @@ def create_user(name: str, photo: str, password: bytes, current_date: str) -> No
         user_repository_logger.exception(f"Error inserting User {user} in database")
         raise UserRepositoryException from exception
     except (UserRepositoryException, Exception) as exception:
-        user_repository_logger.exception(f"Unexpected error inserting user {user} in database")
+        user_repository_logger.exception(
+            f"Unexpected error inserting user {user} in database"
+        )
         raise UserRepositoryException from exception
     else:
         user_repository_logger.info(f"User added to repository: {user}")
+
+
+def update_user_role(user_name: str, new_role: str) -> None:
+    """Update user role
+
+    Args:
+        name (str): user name
+        new_role (str): user role
+
+    Raises:
+        UserNotFoundException: user was not found
+        UserRepositoryException: unexpected error while updating user role
+    """
+    try:
+        user_collection = user_collection_provider.get_user_collection()
+        user = user_collection.find_one({"name": user_name})
+        validate_user_exists(user)
+        user_collection.update_one({"name": user_name}, {"$set": {"role": new_role}})
+    except UserNotFoundException as exception:
+        raise UserNotFoundException from exception
+    except Exception as exception:
+        user_repository_logger.exception(
+            f"Error updating User {user_name} role in database"
+        )
+        raise UserRepositoryException from exception
+    else:
+        user_repository_logger.info(f"User {user_name} role updated to {new_role}")

--- a/Backend/tests/test_API/api_test_user.py
+++ b/Backend/tests/test_API/api_test_user.py
@@ -43,3 +43,7 @@ def delete_user(name: str) -> Response:
 
 def patch_history_playback(user_name: str, song_name: str) -> Response:
     return client.patch(f"/users/{user_name}/playback_history/?song_name={song_name}")
+
+
+def upgrade_to_artist(user_name: str, headers=dict[str, str]) -> Response:
+    return client.patch(f"/users/{user_name}/upgrade_to_artist", headers=headers)


### PR DESCRIPTION
## Description

This pull request introduces a new service method to upgrade user accounts from basic users to artist accounts and a corresponding endpoint to facilitate this functionality. 

## Commit type

- [x] `feat`: Indicates the addition of a new feature or functionality to the project.

## Issue
[#129 ](https://github.com/AntonioMrtz/SpotifyElectron/issues/129)

## Solution

### Service
The `upgrade_user_to_artist` method has been implemented to handle the user account upgrade process. The function performs the following actions:
- Ensures the provided username and JWT token are valid.
- Ensure the user is valid 
- Fetches the user's data from the `user_repository`
- Creates a new artist entry in the `artist_repository` using the retrieved user data. This includes copying the user's playlists, playback history, and other relevant information
- Modifies the user's role in `the user_repository` to "artist"
- Creates a new JWT token with the updated "artist" role
- Includes error handling and logging
- Returns the new token to the caller

### Endpoint

The `upgrade_to_artist` endpoint has been added to facilitate upgrading a user to an artist via an HTTP PATCH request. It performs the following:
- Accepts the username and JWT token in the request
- Calls the `upgrade_user_to_artist` method to process the upgrade
- Returns the new JWT token in the response with a 200 OK status code.
- Handles various exceptions to provide appropriate HTTP responses

### Tests

Tests have been added for the `upgrade_user_to_artist` method and the new endpoint:
- Tests for successful user upgrades
- Tests for user not found during upgrade

## Proposed Changes

- **user_service.py:** Added the `upgrade_user_to_artist` function.
- **user_controller.py:** Added the `PATCH /users/{name}/upgrade_to_artist` endpoint.
- **artist_repository.py:** Added the `create_artist_from_user` function to handle artist creation from existing user data.
- **api_test_user.py:** Added `upgrade_to_artist` client endpoint for testing requests
- **test_user.py:** Added tests for the `upgrade_user_to_artist` function and `upgrade_to_artist` endpoint

## Potential Impact

- Users will have the ability to upgrade to artist status, which affects user management and permissions

## Screenshots

N/A

## Additional Tasks
- The current implementation duplicates user data in both the user and artist collections. Needs further consideration and alternate strategies. 

## Assigned

@AntonioMrtz <!-- Default -->
