### PR TITLE
feat: Add Calculated field/property for artist total streams | [#227]

### DIFF
--- a/Backend/.env.local
+++ b/Backend/.env.local
@@ -1,9 +1,0 @@
-#! Rename this file to .env, more about environments on the official docs hhttps://antoniomrtz.github.io/SpotifyElectron/backend/Environment/
-# ! You can run the app for development using this file and providing a valid MongoDB URL on "MONGO_URI" variable
-MONGO_URI=mongodb://root:root@localhost:27017/
-SECRET_KEY_SIGN=f24e2f3ac557d487b6d879fb2d86f2b2
-SERVERLESS_FUNCTION_URL=https://lambda-url.us-east-1.on.aws/path/
-# PROD,DEV
-ENV_VALUE=DEV
-# BLOB,SERVERLESS
-ARCH=BLOB

--- a/Backend/app/spotify_electron/song/base_song_service.py
+++ b/Backend/app/spotify_electron/song/base_song_service.py
@@ -6,7 +6,6 @@ Redirects to the specific architecture service in case the method is not common
 """
 
 import app.spotify_electron.song.base_song_repository as base_song_repository
-import app.spotify_electron.user.validations.base_user_service_validations as base_user_service_validations  # noqa: E501
 from app.logging.logging_constants import LOGGING_BASE_SONG_SERVICE
 from app.logging.logging_schema import SpotifyElectronLogger
 from app.spotify_electron.genre.genre_schema import Genre, GenreNotValidException
@@ -23,7 +22,6 @@ from app.spotify_electron.song.validations.base_song_service_validations import 
     validate_song_name_parameter,
     validate_song_should_exists,
 )
-from app.spotify_electron.user.user.user_schema import UserNotFoundException
 
 base_song_service_logger = SpotifyElectronLogger(LOGGING_BASE_SONG_SERVICE).getLogger()
 
@@ -157,39 +155,6 @@ def search_by_name(name: str) -> list[SongMetadataDTO]:
     song_names = base_song_repository.get_song_names_search_by_name(name)
 
     return get_songs_metadata(song_names)
-
-
-def get_artist_streams(artist_name: str) -> int:
-    """Get artist songs total streams
-
-    Args:
-        artist_name (str): artist name
-
-    Raises:
-        UserNotFoundException: artist doesn't exists
-        SongServiceException: unexpected error getting artist songs total streams
-
-    Returns:
-        int: the number of streams for the artists songs
-    """
-    try:
-        base_user_service_validations.validate_user_should_exists(artist_name)
-        return base_song_repository.get_artist_total_streams(artist_name)
-    except UserNotFoundException as exception:
-        base_song_service_logger.exception(f"User not found: {artist_name}")
-        raise UserNotFoundException from exception
-    except SongRepositoryException as exception:
-        base_song_service_logger.exception(
-            f"Unexpected error in Song Repository while getting "
-            f"total artist {artist_name} streams"
-        )
-        raise SongServiceException from exception
-    except Exception as exception:
-        base_song_service_logger.exception(
-            f"Unexpected error in Song Service while getting "
-            f"total artist {artist_name} streams"
-        )
-        raise SongServiceException from exception
 
 
 def get_songs_by_genre(genre: Genre) -> list[SongMetadataDTO]:

--- a/Backend/app/spotify_electron/user/artist/artist_controller.py
+++ b/Backend/app/spotify_electron/user/artist/artist_controller.py
@@ -148,38 +148,6 @@ def get_artists(
         )
 
 
-@router.get("/{name}/streams")
-def get_artist_streams(
-    name: str,
-    token: Annotated[TokenData | None, Depends(JWTBearer())],
-) -> Response:
-    """Get artist total streams of his songs
-
-    Args:
-        name (str): artist name
-    """
-    try:
-        total_streams = artist_service.get_streams_artist(artist_name=name)
-
-        total_streams_json = json_converter_utils.get_json_with_iterable_field_from_model(
-            total_streams, "streams"
-        )
-
-        return Response(
-            total_streams_json, media_type="application/json", status_code=HTTP_200_OK
-        )
-    except JsonEncodeException:
-        return Response(
-            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-            content=PropertiesMessagesManager.commonEncodingError,
-        )
-    except (Exception, UserServiceException):
-        return Response(
-            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-            content=PropertiesMessagesManager.commonInternalServerError,
-        )
-
-
 @router.get("/{name}/songs")
 def get_artist_songs(
     name: str,

--- a/Backend/app/spotify_electron/user/artist/artist_schema.py
+++ b/Backend/app/spotify_electron/user/artist/artist_schema.py
@@ -5,6 +5,7 @@ Artist schema for User domain model
 from dataclasses import dataclass
 from typing import Any
 
+from app.spotify_electron.song.base_song_repository import get_artist_total_streams
 from app.spotify_electron.user.user.user_schema import UserDAO, UserDTO
 
 
@@ -13,6 +14,7 @@ class ArtistDAO(UserDAO):
     """Represents artist data in the persistence layer"""
 
     uploaded_songs: list[str]
+    total_streams: int = 0
 
 
 @dataclass
@@ -20,6 +22,7 @@ class ArtistDTO(UserDTO):
     """Represents artist data in the endpoints transfer layer"""
 
     uploaded_songs: list[str]
+    total_streams: int = 0
 
 
 def get_artist_dao_from_document(document: dict[str, Any]) -> ArtistDAO:
@@ -43,6 +46,7 @@ def get_artist_dao_from_document(document: dict[str, Any]) -> ArtistDAO:
         playlists=document["playlists"],
         saved_playlists=document["saved_playlists"],
         uploaded_songs=document["uploaded_songs"],
+        total_streams=get_artist_total_streams(document["name"]),
     )
 
 
@@ -66,4 +70,5 @@ def get_artist_dto_from_dao(artist_dao: ArtistDAO) -> ArtistDTO:
         register_date=artist_dao.register_date,
         saved_playlists=artist_dao.saved_playlists,
         uploaded_songs=artist_dao.uploaded_songs,
+        total_streams=artist_dao.total_streams,
     )

--- a/Backend/app/spotify_electron/user/artist/artist_service.py
+++ b/Backend/app/spotify_electron/user/artist/artist_service.py
@@ -251,53 +251,6 @@ def get_all_artists() -> list[ArtistDTO]:
         return artists_dto
 
 
-# TODO make it a dynamic property
-def get_streams_artist(artist_name: str) -> int:
-    """Get artist songs total streams
-
-    Args:
-        user_name (str): artist name
-
-    Raises:
-        UserNotFoundException: artist doesn't exists
-        UserBadNameException: artist bad name
-        UserUnauthorizedException: user is not artist
-        UserServiceException: unexpected error getting artist total streams
-
-    Returns:
-        int: the total for all artist songs
-    """
-    try:
-        base_user_service_validations.validate_user_name_parameter(artist_name)
-        artist_service_validations.validate_user_should_be_artist(artist_name)
-
-        return base_song_service.get_artist_streams(artist_name)
-    except UserNotFoundException as exception:
-        artist_service_logger.exception(f"Artist not found: {artist_name}")
-        raise UserNotFoundException from exception
-    except UserBadNameException as exception:
-        artist_service_logger.exception(f"Bad Artist Name Parameter: {artist_name}")
-        raise UserBadNameException from exception
-    except UserUnauthorizedException as exception:
-        artist_service_logger.exception(f"User {artist_name} is not Artist")
-        raise UserUnauthorizedException from exception
-    except UserRepositoryException as exception:
-        artist_service_logger.exception(
-            f"Unexpected error in Artist Repository getting artist: {artist_name}"
-        )
-        raise UserServiceException from exception
-    except SongServiceException as exception:
-        artist_service_logger.exception(
-            f"Unexpected error in Song Service getting artist: {artist_name}"
-        )
-        raise UserServiceException from exception
-    except Exception as exception:
-        artist_service_logger.exception(
-            f"Unexpected error in Artist Service getting artist: {artist_name}"
-        )
-        raise UserServiceException from exception
-
-
 # TODO obtain all users in same query
 def get_artists(user_names: list[str]) -> list[ArtistDTO]:
     """Get artists from a list of names

--- a/Backend/tests/test_API/api_test_artist.py
+++ b/Backend/tests/test_API/api_test_artist.py
@@ -43,9 +43,5 @@ def get_artists(headers: dict[str, str]) -> Response:
     return client.get("/artists/", headers=headers)
 
 
-def get_artist_streams(name: str, headers: dict[str, str]) -> Response:
-    return client.get(f"/artists/{name}/streams", headers=headers)
-
-
 def get_artist_songs(name: str, headers: dict[str, str]) -> Response:
     return client.get(f"/artists/{name}/songs", headers=headers)


### PR DESCRIPTION
## Description

This PR refactor/implements the way total streams are calculated and retrieved for artists. Previously, artist total streams were fetched through a separate query via a dedicated endpoint (/artists/{name}/streams). With this update, total streams are now dynamically calculated as part of the artist data model (ArtistDAO and ArtistDTO) and retrieved directly through the main artist endpoint (/artists/{name}). As a result, redundant logic and endpoints related to fetching artist streams have been removed.
Additionally, the test for retrieving total streams has been updated to work with the new logic, ensuring proper functionality.

## Commit type

- [ ] `refactor`: refactoring production code, eg. renaming a variable

## Issue

#227 

## Solution

# Service
The dynamic calculation of total streams for an artist has been implemented within the ArtistDAO. The key changes are:

- Added total_streams field: This field calculates the total streams from the artist’s uploaded songs dynamically when the artist data is fetched.
- Updated get_artist_dao_from_document function: This function now calculates total_streams as part of the artist data, removing the need for a separate query or endpoint.
- Deleted redundant services: Removed the get_artist_streams method from artist_service.py and base_song_service.py as it is no longer needed.

# Endpoint
The following changes were made:

- Removed /artists/{name}/streams endpoint: This API endpoint, which separately fetched an artist's total streams, has been removed as the total streams are now part of the artist data itself.

# Tests
Tests have been updated to reflect the new logic for retrieving total streams:

- Updated test: The test for retrieving an artist’s total streams now works with the new logic of fetching total streams through the main artist endpoint (/artists/{name}).

- Removed redundant test: Any tests related to the /artists/{name}/streams endpoint were removed.

## Proposed Changes

<!-- List the specific changes made in this pull request. -->

- artist_service.py: Removed the get_streams_artist function.
- base_song_service.py: Removed the get_artist_streams function.
- artist_repository.py: Updated to include the total_streams field dynamically within ArtistDAO.
- test_artist.py: Updated tests to verify that total_streams is returned correctly as part of the artist data.

## Potential Impact

This change simplifies the API by consolidating all artist-related data into a single endpoint, improving both performance and maintainability. Users will no longer use a separate endpoint to fetch total streams.

## Screenshots

In the screenshot, the artist "Ade" has two uploaded songs: "era" and "looop", with a total of 6 streams. The total streams are dynamically calculated and retrieved via the /artists/{name} endpoint, summing up streams from all uploaded songs.

![{5622BEBC-F097-47E1-88EF-FB357DC84D63}](https://github.com/user-attachments/assets/696eec61-d6c6-43f7-a15c-3fcf3e5bc362)


## Additional Tasks

N/A

## Assigned

@AntonioMrtz 
