### PR TITLE
Feat/133 disable upload song button while processing request

### DIFF
--- a/Electron/src/__tests__/components/Sidebar/AddSongPlayListAccordion.test.tsx
+++ b/Electron/src/__tests__/components/Sidebar/AddSongPlayListAccordion.test.tsx
@@ -348,6 +348,7 @@ test('AddSongPlaylistAccordion disables the upload button while song is uploadin
   const refreshSidebarDataMock = jest.fn();
   const setIsCloseAllowed = jest.fn();
 
+   // Mocking the fetch API globally
   global.fetch = jest.fn(async (url: string) => {
       if (url === `${Global.backendBaseUrl}/genres/`) {
           return Promise.resolve({
@@ -358,9 +359,10 @@ test('AddSongPlaylistAccordion disables the upload button while song is uploadin
           });
       }
 
-      // Затримка для симуляції завантаження
+      // Delay for loading simulation
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
+      // Mock response for song upload request
       return Promise.resolve({
           json: () => {},
           status: 201,
@@ -408,6 +410,7 @@ test('AddSongPlaylistAccordion disables the upload button while song is uploadin
 
   const uploadSongButton = component.getByTestId('sidebar-addsongplaylistaccordion-submit-song');
 
+  // Verify that the upload button is enabled
   await waitFor(() => {
       expect(uploadSongButton).toBeEnabled();
   });
@@ -416,6 +419,7 @@ test('AddSongPlaylistAccordion disables the upload button while song is uploadin
       fireEvent.click(uploadSongButton);
   });
 
+  // Verify that the upload button is disabled while uploading
   await waitFor(() => {
       expect(uploadSongButton).toBeDisabled();
   });

--- a/Electron/src/components/Sidebar/ModalAddSongPlaylist/Accordion/AddSongPlayListAccordion.tsx
+++ b/Electron/src/components/Sidebar/ModalAddSongPlaylist/Accordion/AddSongPlayListAccordion.tsx
@@ -415,6 +415,7 @@ export default function AddSongPlayListAccordion({
                 onClick={handleSubmitSong}
                 className={`btn btn-lg ${styles.btnSend} d-flex flex-row justify-content-center`}
                 data-testid="sidebar-addsongplaylistaccordion-submit-song"
+                disabled={loadingUploadSong}
               >
                 Subir {loadingUploadSong && <LoadingCircleSmall />}
               </button>


### PR DESCRIPTION
## Description

- Added disabled={loadingUploadSong} to the song upload button. 
- To manually check if the button really becomes unavailable when uploading a song, I made a post request to the route http://127.0.0.1:8000/artists/?name=ArtistName&photo=http://photo.jpg&password=Password, thereby creating a new user with the role 'Artist'. Next step I logged in as the user I just created. And already from this account I uploaded the song and checked whether the button really became unavailable for pressing.
- Created a unit test to test the behavior of the button

## Commit type

  `feat`: indicates the addition of a new feature or functionality to the project.


## Issue

Modify the behaviour of upload song button so its disabled while waiting for the song to be uploaded.

## Solution

Added disabled={loadingUploadSong} to the song upload button

## Proposed Changes

<!-- List the specific changes made in this pull request. -->

- Added disabled={loadingUploadSong} to the song upload button
- A test to check if the button is really unavailable while the song is loading

## Potential Impact

<!-- Describe the impact these changes may have on the project. Include any risks or side effects to consider. -->

## Screenshots

<!-- If applicable, provide screenshots that help visualize the changes made. -->

## Additional Tasks

<!-- List any additional tasks that need to be performed after the pull request is merged, such as documentation updates, additional testing, etc. -->

## Assigned

<!-- Mention the team members assigned to review and merge this pull request. -->

@AntonioMrtz <!-- Default -->
