### PR TITLE
#362: chore: add pre-commit hook for gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,13 @@ repos:
         files: ^Electron/src/
         exclude: ^Electron/src/swagger/
 
-  - repo:  https://github.com/milin/giticket
+  - repo: https://github.com/milin/giticket
     rev: v1.3
     hooks:
-    - id:  giticket
-      args: ['--regex=(\d+)',"--mode=regex_match", '--format={commit_msg} | [#{ticket}]']
+      - id: giticket
+        args: ['--regex=(\d+)', "--mode=regex_match", '--format={commit_msg} | [#{ticket}]']
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
### Description
Add Gitleaks pre-commit hook to prevent secrets from being committed.  

### Commit type
`chore`

### Related Issue
Closes #362

### Solution
- Added `gitleaks` hook in `.pre-commit-config.yaml`
- Configured to scan staged files for hardcoded secrets

### Proposed Changes
- .pre-commit-config.yaml updated with gitleaks hook

### Potential Impact
- Prevents committing secrets
- Slightly increases commit time (~2 seconds)

### How was it tested?
- Ran `pre-commit run --all-files` locally
- Verified hook runs and blocks commits with test secrets

### Screenshots
![image](https://github.com/user-attachments/assets/8a2339af-a96b-4146-91c5-34bf77ec09e6)
---

Additional Tasks
- Reviewed the documentation generated by the pre-commit framework to ensure it's accurate and complete

Assigned
@AntonioMrtz
