### PR TITLE
#373: Remove unused react-icons package

### DIFF
--- a/Electron/package-lock.json
+++ b/Electron/package-lock.json
@@ -24,7 +24,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.0.3",
-        "react-icons": "^4.10.1",
         "react-router-dom": "^6.11.2"
       },
       "devDependencies": {
@@ -18958,15 +18957,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/Electron/package.json
+++ b/Electron/package.json
@@ -49,7 +49,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.0.3",
-    "react-icons": "^4.10.1",
     "react-router-dom": "^6.11.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Remove the unused `react-icons` package from project dependencies. After thorough analysis of the codebase, this package was found to be bundled but never imported or used anywhere in the application.

## Commit type

- `chore`: updating grunt tasks etc; no production code change.

## Issue

#373

## Solution

Conducted a comprehensive search across the entire codebase to verify that `react-icons` is not being used anywhere. The project instead uses Font Awesome icons (loaded via CDN) and Material-UI icons (@mui/icons-material) for the user interface. Since the package was completely unused, it was safely removed from the dependencies to reduce bundle size and improve build performance.

## Proposed Changes

- Removed `react-icons` dependency from `Electron/package.json`
- Updated `Electron/package-lock.json` to reflect the dependency removal
- Verified complete removal from the dependency tree

## Potential Impact

**Positive Impact:**
- Reduced bundle size by removing unused package
- Faster npm install and build times
- Cleaner dependency management
- Better maintainability with only necessary packages

**No Negative Impact:**
- No functionality affected since the package was never used
- All existing icons continue to work (Font Awesome & Material-UI icons)
- All builds and tests pass successfully



## Additional Tasks

None required. The removal is complete and all builds have been verified to work correctly.

## Assigned

@AntonioMrtz <!-- Default -->