### PR TITLE
#282: Vscode settings backend use absolute import

### DIFF
--- a/Backend/.vscode/settings.json
+++ b/Backend/.vscode/settings.json
@@ -6,5 +6,6 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "editor.defaultFormatter": "charliermarsh.ruff",
-  "autoDocstring.docstringFormat": "google-notypes"
+  "autoDocstring.docstringFormat": "google-notypes",
+  "python.analysis.importFormat": "absolute"
 }


### PR DESCRIPTION
## Description

Set Python import to absolute in Vscode settings for backend

## Commit type


- `chore`: updating grunt tasks etc; no production code change.

## Issue

#282 

## Solution

Add following line at the end of Backend/.vscode/settings.json: 

  "python.analysis.importFormat": "absolute"

## Proposed Changes

cf Solution

## Potential Impact

All import paths in Python code shall be absolute

## Screenshots



## Additional Tasks



## Assigned

@AntonioMrtz
