### PR TITLE
#246: Playlist update only introduce fields to change

### DIFF
--- a/Backend/app/spotify_electron/playlist/playlist_repository.py
+++ b/Backend/app/spotify_electron/playlist/playlist_repository.py
@@ -388,3 +388,28 @@ async def remove_songs_from_playlist(name: str, song_names: list[str]) -> None:
         raise PlaylistRepositoryError from exception
     else:
         playlist_repository_logger.info(f"Songs removed from playlist {name}: {song_names}")
+
+
+async def update_playlist_metadata(name: str, update_fields: dict) -> None:
+    """Update only provided metadata fields for a playlist."""
+    try:
+        collection = get_playlist_collection()
+        result_update = await collection.update_one(
+            {"name": name},
+            {"$set": update_fields},
+        )
+        validate_playlist_update(result_update)
+    except PlaylistUpdateError as exception:
+        playlist_repository_logger.exception(
+            f"Error updating playlist metadata {name}: {update_fields}"
+        )
+        raise PlaylistRepositoryError from exception
+    except Exception as exception:
+        playlist_repository_logger.exception(
+            f"Unexpected error updating playlist metadata {name}: {update_fields}"
+        )
+        raise PlaylistRepositoryError from exception
+    else:
+        playlist_repository_logger.info(
+            f"Playlist {name} metadata updated: {update_fields}"
+        )

--- a/Backend/app/spotify_electron/playlist/playlist_repository.py
+++ b/Backend/app/spotify_electron/playlist/playlist_repository.py
@@ -21,6 +21,7 @@ from app.spotify_electron.playlist.validations.playlist_repository_validations i
     validate_playlist_exists,
     validate_playlist_update,
 )
+from typing import Any
 
 playlist_repository_logger = SpotifyElectronLogger(LOGGING_PLAYLIST_REPOSITORY).get_logger()
 
@@ -364,10 +365,10 @@ async def remove_songs_from_playlist(name: str, song_names: list[str]) -> None:
 
     Args:
         name: playlist name
-        song_names: song names
+        song_names: song names to remove
 
     Raises:
-        PlaylistRepositoryError: adding songs to playlist
+        PlaylistRepositoryError: If there's an error removing songs from the playlist
     """
     try:
         collection = get_playlist_collection()
@@ -390,8 +391,17 @@ async def remove_songs_from_playlist(name: str, song_names: list[str]) -> None:
         playlist_repository_logger.info(f"Songs removed from playlist {name}: {song_names}")
 
 
-async def update_playlist_metadata(name: str, update_fields: dict) -> None:
-    """Update only provided metadata fields for a playlist."""
+async def update_playlist_metadata(name: str, update_fields: dict[str, Any]) -> None:
+    """Update only provided metadata fields for a playlist.
+    
+    Args:
+        name: The name of the playlist to update
+        update_fields: Dictionary containing the fields to update and their new values.
+            Possible keys: name, description, photo, is_collaborative, is_public
+            
+    Raises:
+        PlaylistRepositoryError: If there's an error updating the playlist metadata
+    """
     try:
         collection = get_playlist_collection()
         result_update = await collection.update_one(

--- a/Backend/tests/test_API/api_test_playlist.py
+++ b/Backend/tests/test_API/api_test_playlist.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from httpx import Response
 
 from app.__main__ import app
+from tests.test_API.api_token import get_user_jwt_header
 
 client = TestClient(app)
 
@@ -48,21 +49,48 @@ def update_playlist(
 
 def update_playlist_metadata(
     name: str,
-    descripcion: str = None,
+    headers: dict[str, str],
+    description: str = None,
     photo: str = None,
-    headers: dict[str, str] = None,
-    nuevo_nombre: str = None,
+    new_name: str = None,
+    is_collaborative: bool = None,
+    is_public: bool = None,
 ) -> Response:
+    """Update playlist metadata fields.
+    
+    Args:
+        name: Current playlist name
+        headers: JWT headers for authentication
+        description: Optional new description
+        photo: Optional new photo URL
+        new_name: Optional new name for the playlist
+        is_collaborative: Optional new collaborative status
+        is_public: Optional new public status
+        
+    Returns:
+        Response from the API
+    """
     url = f"/playlists/{name}/metadata"
     params = {}
-    if nuevo_nombre:
-        params["new_name"] = nuevo_nombre
-    if descripcion is not None:
-        params["description"] = descripcion
+    
+    if new_name:
+        params["new_name"] = new_name
+    if description is not None:
+        params["description"] = description
     if photo is not None:
         params["photo"] = photo
+    if is_collaborative is not None:
+        params["is_collaborative"] = str(is_collaborative).lower()
+    if is_public is not None:
+        params["is_public"] = str(is_public).lower()
+        
     file_type_header = {"Content-Type": "application/json"}
-    return client.patch(url, params=params, headers={**file_type_header, **(headers or {})})
+    
+    return client.patch(
+        url,
+        params=params,
+        headers={**file_type_header, **headers}
+    )
 
 
 def delete_playlist(name: str) -> Response:
@@ -88,4 +116,26 @@ def remove_song_from_playlist(
 ) -> Response:
     return client.delete(
         f"/playlists/{name}/songs/", params={"song_names": song_names}, headers=headers
+    )
+
+
+def create_basic_playlist(name: str, owner: str) -> Response:
+    """Helper function to create a basic playlist for testing.
+    
+    Args:
+        name: Name of the playlist
+        owner: Owner of the playlist
+        
+    Returns:
+        Response from the API
+    """
+    photo = "https://example.com/photo.jpg"
+    description = "Test playlist"
+    jwt_headers = get_user_jwt_header(username=owner, password="password")
+    
+    return create_playlist(
+        name=name,
+        descripcion=description,
+        photo=photo,
+        headers=jwt_headers
     )

--- a/Backend/tests/test_API/api_test_playlist.py
+++ b/Backend/tests/test_API/api_test_playlist.py
@@ -46,6 +46,25 @@ def update_playlist(
     return client.put(url, json=payload, headers={**file_type_header, **headers})
 
 
+def update_playlist_metadata(
+    name: str,
+    descripcion: str = None,
+    photo: str = None,
+    headers: dict[str, str] = None,
+    nuevo_nombre: str = None,
+) -> Response:
+    url = f"/playlists/{name}/metadata"
+    params = {}
+    if nuevo_nombre:
+        params["new_name"] = nuevo_nombre
+    if descripcion is not None:
+        params["description"] = descripcion
+    if photo is not None:
+        params["photo"] = photo
+    file_type_header = {"Content-Type": "application/json"}
+    return client.patch(url, params=params, headers={**file_type_header, **(headers or {})})
+
+
 def delete_playlist(name: str) -> Response:
     return client.delete(f"/playlists/{name}")
 


### PR DESCRIPTION
## Description
## Refactor Playlist Update Logic

This PR introduces partial playlist metadata updates and separates song management operations, making the API more RESTful and efficient.

### Changes Made
- ✨ Added PATCH endpoint for partial metadata updates (name, description, photo)
- 🔧 Separated song management into dedicated endpoints
- 🧪 Added comprehensive test coverage
- 📝 Improved type hints and documentation
- 🔄 Standardized HTTP status codes using Starlette
- 🌐 Changed Spanish parameter names to English

### Testing
- Added individual test cases for each metadata field
- Added edge case tests for metadata updates
- Verified error cases and authorization
- All tests passing with improved coverage

### Breaking Changes
- Old `update_playlist` replaced with `update_playlist_metadata`
- Parameter name changes (descripcion → description)

### Checklist
- [x] Followed Contributing Guidelines
- [x] Followed git convention
- [x] Added comprehensive tests
- [x] Set base to development-v2.30
- [x] Updated documentation
- [x] No linting issues

Fixes #246


## Assigned

<!-- Mention the team members assigned to review and merge this pull request. -->

@AntonioMrtz <!-- Default -->
