### PR TITLE
feat: add hide/show password toggle button

### DIFF
--- a/Electron/src/__tests__/pages/RegisterMenu.test.tsx
+++ b/Electron/src/__tests__/pages/RegisterMenu.test.tsx
@@ -275,6 +275,38 @@ describe('RegisterMenu Component', () => {
     expect(mockSetIsSigningUp).toHaveBeenCalledWith(false);
   });
 
+  test('toggles password visibility for password field', () => {
+    const component = render(
+      <RegisterMenu setIsSigningUp={jest.fn()} />,
+    );
+
+    const passwordInput = component.getByPlaceholderText(
+      t('registerMenu.form-password'),
+    );
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    const toggleButtons = component.getAllByLabelText('Show password');
+    fireEvent.click(toggleButtons[0]);
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+  });
+
+  test('toggles password visibility for confirm password field', () => {
+    const component = render(
+      <RegisterMenu setIsSigningUp={jest.fn()} />,
+    );
+
+    const confirmPasswordInput = component.getByPlaceholderText(
+      t('registerMenu.form-password-repeat'),
+    );
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+    const toggleButtons = component.getAllByLabelText('Show password');
+    fireEvent.click(toggleButtons[1]);
+
+    expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+  });
+
   test('Change to login menu', () => {
     const mockSetIsSigningUp = jest.fn();
 

--- a/Electron/src/__tests__/pages/StartMenu.test.tsx
+++ b/Electron/src/__tests__/pages/StartMenu.test.tsx
@@ -220,6 +220,31 @@ describe('StartMenu Component', () => {
     expect(setIsSigningUpMock).toHaveBeenCalledWith(true);
   });
 
+  test('toggles password visibility when clicking the toggle button', async () => {
+    await act(async () => {
+      render(
+        <StartMenu
+          setIsLogged={setIsLoggedMock}
+          setIsSigningUp={setIsSigningUpMock}
+        />,
+      );
+    });
+
+    const passwordInput = screen.getByPlaceholderText(
+      t('startMenu.form-password'),
+    );
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    const toggleButton = screen.getByLabelText('Show password');
+    fireEvent.click(toggleButton);
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    expect(screen.getByLabelText('Hide password')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Hide password'));
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
   test('change language from english to spanish', async () => {
     await act(async () => {
       render(

--- a/Electron/src/pages/StartMenu/RegisterMenu.tsx
+++ b/Electron/src/pages/StartMenu/RegisterMenu.tsx
@@ -43,6 +43,10 @@ export default function RegisterMenu({ setIsSigningUp }: PropsRegisterMenu) {
     null,
   );
 
+  /* Password visibility */
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   /* Loading state */
   const [loading, setLoading] = useState(false);
 
@@ -199,33 +203,55 @@ export default function RegisterMenu({ setIsSigningUp }: PropsRegisterMenu) {
               className="d-flex flex-column justify-content-start"
             >
               {t('registerMenu.form-password')}
-              <input
-                type="password"
-                name="password"
-                id="password"
-                placeholder={t('registerMenu.form-password')}
-                onChange={handleChange}
-                disabled={loading}
-                spellCheck={false}
-                required
-              />
+              <div className={styles.passwordInputWrapper}>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  name="password"
+                  id="password"
+                  placeholder={t('registerMenu.form-password')}
+                  onChange={handleChange}
+                  disabled={loading}
+                  spellCheck={false}
+                  required
+                />
+                <button
+                  type="button"
+                  className={styles.passwordToggleButton}
+                  onClick={() => setShowPassword(!showPassword)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  disabled={loading}
+                >
+                  {showPassword ? '🙈' : '👁'}
+                </button>
+              </div>
             </label>
 
             <label
-              htmlFor="password"
+              htmlFor="confirmpassword"
               className="d-flex flex-column justify-content-start"
             >
               {t('registerMenu.form-password-repeat')}
-              <input
-                type="password"
-                name="confirmpassword"
-                id="confirmpassword"
-                placeholder={t('registerMenu.form-password-repeat')}
-                onChange={handleChange}
-                disabled={loading}
-                spellCheck={false}
-                required
-              />
+              <div className={styles.passwordInputWrapper}>
+                <input
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  name="confirmpassword"
+                  id="confirmpassword"
+                  placeholder={t('registerMenu.form-password-repeat')}
+                  onChange={handleChange}
+                  disabled={loading}
+                  spellCheck={false}
+                  required
+                />
+                <button
+                  type="button"
+                  className={styles.passwordToggleButton}
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+                  disabled={loading}
+                >
+                  {showConfirmPassword ? '🙈' : '👁'}
+                </button>
+              </div>
             </label>
           </div>
 

--- a/Electron/src/pages/StartMenu/StartMenu.tsx
+++ b/Electron/src/pages/StartMenu/StartMenu.tsx
@@ -34,6 +34,9 @@ export default function StartMenu({
   setIsLogged,
   setIsSigningUp,
 }: PropsStartMenu) {
+  /* Password visibility */
+  const [showPassword, setShowPassword] = useState(false);
+
   /* Popover */
   const [isOpenPopover, setisOpenPopover] = useState(false);
   const [propsPopOver, setPropsPopOver] = useState<PropsInfoPopover | null>(
@@ -283,16 +286,27 @@ export default function StartMenu({
               className="d-flex flex-column justify-content-start"
             >
               {t('startMenu.form-password')}
-              <input
-                type="password"
-                name="password"
-                id="password"
-                placeholder={t('startMenu.form-password')}
-                onChange={handleChange}
-                disabled={loginLoading}
-                spellCheck={false}
-                required
-              />
+              <div className={styles.passwordInputWrapper}>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  name="password"
+                  id="password"
+                  placeholder={t('startMenu.form-password')}
+                  onChange={handleChange}
+                  disabled={loginLoading}
+                  spellCheck={false}
+                  required
+                />
+                <button
+                  type="button"
+                  className={styles.passwordToggleButton}
+                  onClick={() => setShowPassword(!showPassword)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  disabled={loginLoading}
+                >
+                  {showPassword ? '🙈' : '👁'}
+                </button>
+              </div>
             </label>
 
             <button

--- a/Electron/src/pages/StartMenu/startMenu.module.css
+++ b/Electron/src/pages/StartMenu/startMenu.module.css
@@ -142,6 +142,38 @@
   opacity: 50%;
 }
 
+.passwordInputWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.passwordInputWrapper input {
+  width: 100%;
+  padding-right: 2.5rem;
+}
+
+.passwordToggleButton {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.passwordToggleButton:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
 @media (max-width: 1336px) {
   .contentWrapper h1 {
     margin-bottom: 2rem !important;


### PR DESCRIPTION
## Summary
- Add password visibility toggle buttons (show/hide) to the login form (StartMenu) and register form (RegisterMenu)
- Each password input field now has an eye icon button that toggles the input type between `password` and `text`
- Register form supports independent toggles for both password and confirm password fields
- Added CSS styles for the toggle button positioned inside the input wrapper
- Added unit tests for toggle functionality in both StartMenu and RegisterMenu test suites

## Test plan
- [x] Toggle button renders next to password input on login page
- [x] Clicking toggle changes input type from `password` to `text` and vice versa
- [x] Toggle button renders for both password fields on register page
- [x] Each toggle operates independently on register page
- [x] Toggle buttons are disabled when form is in loading state
- [x] Aria labels update correctly (`Show password` / `Hide password`)

Closes #368

/attempt #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)